### PR TITLE
Token in dotfile breaks this without info when it has a newline at EOF

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = function(program){
       Github Authorization
     */
 
+    console.info('>> Authorizing');
     token = yield auth(opt);
     if (token) {
       yield saveToken(token);
@@ -104,7 +105,7 @@ function parse (config) {
 
 function readToken() {
   if (fs.existsSync(dotfile)) {
-    return fs.readFileSync(dotfile).toString();
+    return fs.readFileSync(dotfile, 'utf8').replace(/\n$/, '');
   }
   return null;
 }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -11,6 +11,14 @@ module.exports = function *auth(opt) {
       type: 'oauth',
       token: opt.token
     });
+    // Test the token.
+    try {
+      yield test(github);
+    } catch(e) {
+      console.error('>> Token error');
+      console.log(e.message);
+      process.exit(1);
+    }
   }
 
   /*
@@ -29,6 +37,7 @@ module.exports = function *auth(opt) {
       return res.token;
     } catch(e) {
       console.error('>> Authorize error');
+      console.log(e.message);
       process.exit(1);
     }
   }
@@ -39,6 +48,15 @@ function create (github) {
     github.authorization.create({
       scopes: ['public_repo'],
       note: 'github-labels'
+    }, callback);
+  };
+}
+
+function test (github) {
+  return function (callback) {
+    // Test the github user who will always exist.
+    github.user.getFrom({
+      user:'github'
     }, callback);
   };
 }


### PR DESCRIPTION
If a user places a token in `~/.github-labels` themselves, it's very likely there'll be a `\n` at the end when read into node as a string. With that `\n`, GitHub errors with `Bad credentials`.

This PR removes a trailing newline if it's there, then tests the token before moving on. If the token fails, more verbose errors are output.

In general, I think it's a good idea to always output the error message that GitHub returns so users are informed.

``` bash
$: echo 'bad-token' > ~/.github-labels
$: labels -c ~/.config/github-labels/labels-api.json henrahmagix/labels-test
>> Authorizing
>> Token error
{"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}
```

---

Commit message:

> ## Fix malformed token when \n is at the end.
> - When the token is read from the dotfile, sometimes it will have
>   a newline at the end with which GitHub errors: Bad credentials.
>   This does a string replace to remove newlines.
> - Test the token when being read from the dotfile before deciding
>   everything is ok. Error if authentication fails.
> - Show GitHub error message when failing so the user understands
>   what's going wrong.
