### PR TITLE
Add pathPrefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Force option will delete all existing labels, otherwise will create label when n
 $ labels -c path/to/conf.json -f user/repo
 ```
 
-## GitHub Entreprise configuration
+## GitHub Enterprise configuration
 
-If you're using a private GitHub, you'll need to pass some additional parameters to target your environment
+If you're using a GitHub Enterprise instance, you'll need to pass some additional parameters to target your environment
 * `host` - The hostname of your GHE instance.
 * `pathPrefix` - The path to the API. Frequently for GHE this will be `/api/v3`.
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,20 @@ $ labels -c path/to/conf.json -f user/repo
 
 ## GitHub Entreprise configuration
 
-If you're using a private GitHub, you'll need to pass its domain name as parameter.
+If you're using a private GitHub, you'll need to pass some additional parameters to target your environment
+* `host` - The hostname of your GHE instance.
+* `pathPrefix` - The path to the API. Frequently for GHE this will be `/api/v3`.
 
 ```
-$ labels -c path/to/conf.json -h github.myhost.com user/repo
+$ labels -c path/to/conf.json -h github.myhost.com -p /api/v3 user/repo
 ```
 
-It currently only support the default path to the API `/api/v3` on port 80.
+You can also provide the OAuth token to be used directly via the `--token` parameter. 
+This is useful when your GHE environment does not allow user/pass login.
+
+```
+$ labels -c path/to/conf.json -h github.myhost.com -p /api/v3 -t PERSONAL_TOKEN_123 user/repo
+```
 
 ### Export from GitHub website
 

--- a/bin/labels
+++ b/bin/labels
@@ -12,10 +12,13 @@ program
   .option('-f, --force', 'force delete all labels')
   .option('-h, --host <hostname>', 'host for GitHub server')
   .option('-t, --token <token>', 'github token')
+  .option('-p, --pathPrefix <prefix>', 'path prefix for GitHub API')
   .on('--help', function() {
     console.log('  Examples:');
     console.log('');
     console.log('    $ labels -c ~/labels.json popomore/test');
+    console.log('');
+    console.log('    $ labels -c ~/labels.json -h github.myenterprise.com -p /api/v3 -t PERSONAL_TOKEN_123 popomore/test');
     console.log('');
   })
   .parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = program => {
   const github = new GitHubApi({
     version: '3.0.0',
     protocol: 'https',
-    pathPrefix: program.prefix,
+    pathPrefix: program.pathPrefix,
     host: program.host,
   });
   co(function* () {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = program => {
   const github = new GitHubApi({
     version: '3.0.0',
     protocol: 'https',
-    pathPrefix: program.host,
+    pathPrefix: program.prefix,
     host: program.host,
   });
   co(function* () {


### PR DESCRIPTION
In the change to HTTPS, it looks like the `pathPrefix` option for the GitHub API client was changed to use the program host. Looking at the [docs](https://github.com/mikedeboer/node-github) for that client, it looks like for public GitHub you leave that setting null, but for GitHub Enterprise it usually needs to be `"/api/v3"`

Rather than try to guess at the correct behavior, I added another command line flag for setting that prefix. No options provided still works for public GH, and this now works for our GitHub Enterprise installation which requires the `"/api/v3"` prefix.
